### PR TITLE
Fixes area totals in certain situations

### DIFF
--- a/server/comments.js
+++ b/server/comments.js
@@ -62,7 +62,7 @@ function totalDeltasForArea(areaDelta, delta) {
 	const chunkSizes = ['firstSizes', 'secondSizes']
 		.map((property, index) => chunksInUse[index].reduce(
 			(acc, chunkName) => {
-				const chunk = delta.chunks.find(chunk => chunk.name === chunkName) || {};
+				const chunk = delta.allChunks.find(chunk => chunk.name === chunkName) || {};
 				acc = sumSizesOf(acc, chunk[property]);
 				return acc;
 			},

--- a/server/db.js
+++ b/server/db.js
@@ -2,7 +2,7 @@ const _ = require('lodash');
 const knex = require('knex');
 const config = require('./knexfile');
 const { timed } = require('./utils');
-const { deltaFromStats, deltaFromStatsAndGroups } = require('./delta');
+const { deltaFromStats, deltaFromStatsAndGroups, allChunksFromStats } = require('./delta');
 
 const K = knex(config);
 
@@ -326,8 +326,15 @@ exports.getPushDelta = function (first, second, options) {
 	]).then(([[firstStats, secondStats], [firstGroups, secondGroups]]) =>
 		deltaFromStatsAndGroups(firstStats, firstGroups, secondStats, secondGroups, options)
 	);
+	const allChunks = statsRequest.then(([firstStats, secondStats]) =>
+		allChunksFromStats(firstStats, secondStats)
+);
 
-	return Promise.all([chunksDelta, groupsDelta]).then(([chunks, groups]) => ({ chunks, groups }));
+	return Promise.all([
+		chunksDelta,
+		groupsDelta,
+		allChunks
+	]).then(([chunks, groups, allChunks]) => ({ chunks, groups, allChunks }));
 };
 
 function applyBranchFilter(query, branch) {

--- a/server/delta.js
+++ b/server/delta.js
@@ -133,6 +133,47 @@ function byGroupName(group) {
 	return g => name === canonicalName(g.group);
 }
 
+function allChunksFromStats(firstStats, secondStats) {
+	const chunks = [];
+	for (const firstStat of firstStats) {
+		const secondStat = secondStats.find(byChunkName(firstStat));
+		const name = (secondStat || firstStat).chunk; // prefer the second chunk's name
+		const firstHash = firstStat.hash;
+		const secondHash = secondStat ? secondStat.hash : null;
+
+		const firstSizes = sizesOf(firstStat);
+		const secondSizes = sizesOf(secondStat);
+
+		chunks.push({
+			name,
+			firstHash,
+			firstSizes,
+			secondHash,
+			secondSizes,
+		});
+	}
+
+	for (const secondStat of secondStats) {
+		if (!firstStats.find(byChunkName(secondStat))) {
+			const name = secondStat.chunk;
+			const firstHash = null;
+			const firstSizes = null;
+			const secondHash = secondStat.hash;
+			const secondSizes = sizesOf(secondStat);
+
+			chunks.push({
+				name,
+				firstHash,
+				firstSizes,
+				secondHash,
+				secondSizes,
+			});
+		}
+	}
+
+	return chunks;
+}
+
 function deltaFromStats(firstStats, secondStats) {
 	const deltas = [];
 
@@ -266,6 +307,7 @@ function deltaFromStatsAndGroups(firstStats, firstGroups, secondStats, secondGro
 }
 
 exports.deltaFromStats = deltaFromStats;
+exports.allChunksFromStats = allChunksFromStats;
 exports.deltaFromStatsAndGroups = deltaFromStatsAndGroups;
 exports.sumSizesOf = sumSizesOf;
 exports.ZERO_SIZE = ZERO_SIZE;


### PR DESCRIPTION
We need a new entry with all chunks in the response from `getPushDelta`, so that we can correctly calculate the per-area totals in `comments.js`.

Previously, we were using `chunks`, which only includes the chunks which changed in size. This would mean that if a chunk were to no longer be used in one area, but remain unchanged, the total for that area would be incorrectly calculated.